### PR TITLE
portability hotfix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # require cmake v3.0
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 2.8.4)
 
 # Project info
 project(OpenRPG)
@@ -8,25 +8,6 @@ set(OpenRPG_VERSION_MINOR 0)
 set(OpenRPG_VERSION_TWEAK 2)
 set(OpenRPG_VERSION_SUFFIX "dev")
 add_definitions(-DVERSION_STR="v${OpenRPG_VERSION_MAJOR}.${OpenRPG_VERSION_MINOR}.${OpenRPG_VERSION_TWEAK}-${OpenRPG_VERSION_SUFFIX}")
-
-# Git build options
-set(USE_GIT_VERSIONING true CACHE BOOL "Determines whether to use git versioning if available.")
-
-find_package(Git)
-if(${GIT_FOUND} AND ${USE_GIT_VERSIONING})
-		add_definitions(-DWITH_GIT_INFO=1)
-		# The following execute_process stolen from http://xit0.org/2013/04/cmake-use-git-branch-and-commit-details-in-project/
-		# thanks, bud.
-		# Get the latest abbreviated commit hash of the working branch
-		execute_process(
-			COMMAND git log -1 --format=%h
-			WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-			OUTPUT_VARIABLE GIT_COMMIT_HASH
-			OUTPUT_STRIP_TRAILING_WHITESPACE
-		)
-
-		add_definitions(-DGIT_COMMIT_STR="${GIT_COMMIT_HASH}")
-endif(${GIT_FOUND} AND ${USE_GIT_VERSIONING})
 
 set(CMAKE_SOURCE_DIR ${CMAKE_SOURCE_DIR}/src)
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 A handy dandy helper program for playing D&amp;D! (This is just a concept and will need to be expanded on)
 
 # Building
-Currently we require `cmake` (at least v3.0) and `make`
+Currently we require `cmake` (at least v2.8.4) and `make`
 
-Create a build directory `$ mkdir build &&  cd build`  
+Create a build directory `$ mkdir build && cd build`  
 Run cmake `$ cmake ..`  
 Run make `$ make`  
 Run make check `$ make check`  


### PR DESCRIPTION
## Description
This is a hotfix to increase portability across LTS systems and devs that may not have access to CMake >= 2.8.5 (i.e Cloud9)


## Specific Changes proposed
Change required CMake v3.0 -> v2.8.4

## Requirements Checklist
- [X] Pull request made to development branch
- [X] Feature implemented / Bug fixed
- [X] Reviewed by a Core Contributor
  - [X] Reviewed by: @incomingstick
