### PR TITLE
Changed Name generator to only add a first name if a gender is provided

### DIFF
--- a/src/names/names.cpp
+++ b/src/names/names.cpp
@@ -53,13 +53,12 @@ NameGenerator::NameGenerator(string race, string gender) {
 string NameGenerator::make_name() {
     string ret;
 
-    ret += make_first();
-
     if(!gender.empty()) {
+        ret += make_first();
         ret += " ";
-
-        ret += make_last();
     }
+    
+    ret += make_last();
 
     return ret;
 }


### PR DESCRIPTION
## Description
Fixes a bug where the name is generated as NULL if no gender is provided, as it would only generate a first name. Unless first names are gender-neutral, this will return null as there is no such namefile.
This patch changes the behavior of the name generator to return a lastname instead, which are gender neutral, resolving the issue.

## Specific Changes proposed
Please list the specific changes involved in this pull request.

## Requirements Checklist
- [x] Feature implemented | Bug fixed
- [ ] Reviewed by a Core Contributor
  - [ ] Reviewed by: @
