### PR TITLE
Fix being able to create anything less than a 2-sided die

### DIFF
--- a/include/roll/die.h
+++ b/include/roll/die.h
@@ -18,7 +18,13 @@ class Die {
     private:
         const int MAX = 20;
     public:
-        Die(int max):MAX(max){};
+        Die(int max):MAX(
+                /* If max is less than 2, set MAX to 2; else set MAX to max.
+                 * Ensures we don't have nonsense like a 1- or 0-sided die
+                 * (or a negative-sided die) */
+                (max < 2) ? 2
+                          : max
+                ){};
         int roll() {
             std::random_device rd;
             std::mt19937 mt(rd());


### PR DESCRIPTION
## Description
Fix bug in Issue #90 

## Specific Changes proposed
Threw in a check on creation of a new Die that ensures that a die with less than 2 sides never exists

## Requirements Checklist
- [X] Feature implemented | Bug fixed
- [x] Reviewed by a Core Contributor
  - [ ] Reviewed by: @
