### PR TITLE
fixed index size check in request_selection function

### DIFF
--- a/src/character/character.cpp
+++ b/src/character/character.cpp
@@ -266,7 +266,7 @@ namespace ORPG {
             if(factory.has_options())
                 list = factory.current_options();
 
-            while(index < 0 || index > (signed)list.size()) {
+            while(index < 0 || index >= (signed)list.size()) {
 
                 int tick = 0;
 


### PR DESCRIPTION
fixed index size check in request_selection function, stopping seg fault when entering index 1 above the max

## Description
When selecting a race if you chose an index equal to the size of the selection it would seg fault because indices refer to the list item 1 less than the length of the list. I fixed the check so that the program only continues if the user inputs a valid index.


## Specific Changes proposed
change the check from (index < 0 || index > (signed)list.size()) to (index < 0 || index >= (signed)list.size())

## Requirements Checklist
- [X] Bug fixed (#96)
- [X] Reviewed by a Core Contributor
  - [X] Reviewed by: @incomingstick 
