### PR TITLE
fixed the math expression for calculating ability modifiers

### DIFF
--- a/include/character/character.h
+++ b/include/character/character.h
@@ -277,7 +277,7 @@ namespace ORPG {
      *
      * NOTE(incomingstick): This is intended to always round down. Data loss is acceptable.
      **/
-    inline int8 CHARACTER_EXPORT modifier(int abil) { return (abil - 10) / 2; };
+    inline int8 CHARACTER_EXPORT modifier(int abil) { return abil / 2 - 5; };
 
     // TODO take an in depth look at what should and should not be public here
     class CHARACTER_EXPORT Character {


### PR DESCRIPTION
fixed the math expression for calculating ability modifiers to properly calculate scores less than 10

## Description
When given a score of less than 10 the program would give it the wrong modifier due to an improper math expression. I changed it to a math expression that properly calculated it


## Specific Changes proposed
Change return (abil - 10) / 2 to return abil / 2 - 5
This ensures proper calculation of values less than 10

## Requirements Checklist
- [issue 97] Feature implemented | Bug fixed
- [I don't know what you want me to put here] Reviewed by a Core Contributor
  - [I don't know what you want me to put here] Reviewed by: @
